### PR TITLE
Makefile: honor an externally provided CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
 # Tools and flags
 #
 
-CC = $(CROSS_COMPILE)gcc
+CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS = -Wall
 INCLUDES = -I$(SRC_DIR)


### PR DESCRIPTION
Hi folks! Checking in from AsteroidOS here.

Let the build system pick the compiler. The Makefile hard-codes its own CC and ignores the cross-compiler the build environment provides, so cross-compiles wrongly fall back to the host's gcc. Switching `=` to `?=` honors a compiler passed in by the environment or command line, and keeps the old default when none is given. The sibling libraries libgbinder and libdbusaccess already do this.

Found while cross-compiling libwspcodec with Yocto/OpenEmbedded for a 32-bit ARM AsteroidOS watch port: OpenEmbedded exports CC for the target toolchain but does not set CROSS_COMPILE, so `CC = $(CROSS_COMPILE)gcc` resolved to the host gcc.

I should add that this is a convenience more than a blocker, so do with it as you wish.